### PR TITLE
Use PG rows instead of complicated conditions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - jruby-9.2.8.0
   - ruby-head
-  - jruby
+  - jruby-head
 before_install: gem install bundler
 env:
   - SEQUEL_VERSION="~> 4.0"
@@ -19,3 +20,4 @@ services:
   - postgresql
 allow_failures:
   - rvm: ruby-head
+  - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,21 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.3
-  - 2.4.2
-  - 2.5.0
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
+  - ruby-head
   - jruby
-before_install: gem install bundler -v 1.14.6
+before_install: gem install bundler
 env:
-  - SEQUEL_VERSION='~> 4.0'
-  - SEQUEL_VERSION='~> 5.0'
+  - SEQUEL_VERSION="~> 4.0"
+  - SEQUEL_VERSION="~> 5.0"
 gemfile:
   - gemfiles/ci.gemfile
 addons:
   postgresql: "9.6"
 services:
   - postgresql
+allow_failures:
+  - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ rvm:
   - 2.5
   - 2.6
   - jruby-9.2.8.0
-  - ruby-head
-  - jruby-head
 before_install: gem install bundler
 env:
   - SEQUEL_VERSION="~> 4.0"
@@ -18,6 +16,3 @@ addons:
   postgresql: "9.6"
 services:
   - postgresql
-allow_failures:
-  - rvm: ruby-head
-  - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,34 @@
 sudo: false
+
 language: ruby
+
 rvm:
   - 2.3
   - 2.4
   - 2.5
   - 2.6
   - jruby-9.2.8.0
+  - ruby-head
+  - jruby-head
+
 before_install: gem install bundler
-env:
-  - SEQUEL_VERSION="~> 4.0"
-  - SEQUEL_VERSION="~> 5.0"
-gemfile:
-  - gemfiles/ci.gemfile
+
+env: SEQUEL_VERSION="~> 5.0"
+
+gemfile: gemfiles/ci.gemfile
+
 addons:
   postgresql: "9.6"
+
 services:
   - postgresql
+
+matrix:
+  include:
+    - rvm: 2.6
+      env: SEQUEL_VERSION="~> 4.0"
+  allow_failures:
+    - rvm: ruby-head
+      env: SEQUEL_VERSION="~> 5.0"
+    - rvm: jruby-head
+      env: SEQUEL_VERSION="~> 5.0"

--- a/README.md
+++ b/README.md
@@ -2,11 +2,21 @@
 
 This dataset extension provides the method #in_batches. The method splits dataset in parts and yields it.
 
-You can set following options:
-  - pk Overrides primary key of your dataset
-  - of sets chunk size (1000 by default)
-  - start as a hash { [column]: <start_value> } represents frame start for batch processing
-  - finish as a hash represents frame end
+You can set the following options:
+
+### pk
+Overrides primary key of your dataset. This option is required in case your table doesn't have a real PK, otherwise you will get `Sequel::Extensions::Batches::MissingPKError`.
+
+Note that you have to provide columns that don't contain NULL values, otherwise this may not work as intended. You will receive `Sequel::Extensions::Batches::NullPKError` in case batch processing detects a NULL value on it's way, but it's not guaranteed since it doesn't check all the rows for performance reasons.
+
+### of
+Sets chunk size (1000 by default).
+
+### start
+A hash `{ [column]: <start_value> }` that represents frame start for batch processing. Note that you will get `Sequel::Extensions::Batches::InvalidPKError` in case you provide a hash with wrong keys (ordering matters as well).
+
+### finish
+Same as `start` but represents the frame end.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This dataset extension provides the method #in_batches. The method splits dataset in parts and yields it.
 
+Note: currently only PostgreSQL database is supported.
+
 You can set the following options:
 
 ### pk

--- a/lib/sequel/extensions/batches.rb
+++ b/lib/sequel/extensions/batches.rb
@@ -5,45 +5,23 @@ module Sequel
   module Extensions
     module Batches
       MissingPKError = Class.new(StandardError)
+      NullPKError = Class.new(StandardError)
 
       def in_batches(pk: nil, of: 1000, start: nil, finish: nil)
-        pk ||=
-          db.schema(first_source)
-            .select { |x| x[1][:primary_key] }
-            .map(&:first) or raise MissingPKError
+        pk ||= db.schema(first_source).select { |x| x[1][:primary_key] }.map(&:first)
+        raise MissingPKError if pk.empty?
 
         qualified_pk = pk.map { |x| Sequel[first_source][x] }
-        pk_combinations = pk.map.with_index { |x, i| pk[0..i] }
 
-        # For composite PK (x, y, z) this will generate the following WHERE expression:
-        # (x > ?) OR (x = ? AND y > ?) OR (x = ? AND y = ? AND z > ?)
-        conditions = lambda do |values, mode: :start, including: true|
-          or_conditions = pk_combinations.map do |keys|
-            and_conditions = keys.map.with_index do |key, index|
-              value = values.fetch(key)
-
-              # All conditions should use equality except for the last one
-              if index == keys.size - 1
-                mode == :finish ? Sequel[key] < value : Sequel[key] > value
-              else
-                Sequel[key] =~ value
-              end
-            end
-
-            and_conditions.reduce(:&)
-          end
-
-          if including
-            including_expr = pk.map { |key| Sequel[key] =~ values.fetch(key) }.reduce(:&)
-            or_conditions << including_expr
-          end
-
-          or_conditions.reduce(:|)
+        conditions = lambda do |pk, sign:|
+          raise NullPKError if pk.values.any?(&:nil?)
+          row_expr = Sequel.function(:row, *pk.values)
+          Sequel.function(:row, *qualified_pk).public_send(sign, row_expr)
         end
 
         base_ds = order(*qualified_pk)
-        base_ds = base_ds.where(conditions.call(start)) if start
-        base_ds = base_ds.where(conditions.call(finish, mode: :finish)) if finish
+        base_ds = base_ds.where(conditions.call(start, sign: :>=)) if start
+        base_ds = base_ds.where(conditions.call(finish, sign: :<=)) if finish
 
         pk_ds = db.from(base_ds).select(*pk).order(*pk)
         actual_start = pk_ds.first
@@ -51,20 +29,20 @@ module Sequel
 
         return unless actual_start && actual_finish
 
-        base_ds = base_ds.where(conditions.call(actual_start))
-        base_ds = base_ds.where(conditions.call(actual_finish, mode: :finish))
+        base_ds = base_ds.where(conditions.call(actual_start, sign: :>=))
+        base_ds = base_ds.where(conditions.call(actual_finish, sign: :<=))
 
         current_instance = nil
 
         loop do
           if current_instance
-            working_ds = base_ds.where(conditions.call(current_instance.to_h, including: false))
+            working_ds = base_ds.where(conditions.call(current_instance.to_h, sign: :>))
           else
             working_ds = base_ds
           end
 
           current_instance = db.from(working_ds.limit(of)).select(*pk).order(*pk).last or break
-          working_ds = working_ds.where(conditions.call(current_instance.to_h, mode: :finish))
+          working_ds = working_ds.where(conditions.call(current_instance.to_h, sign: :<=))
 
           yield working_ds
         end

--- a/lib/sequel/extensions/batches.rb
+++ b/lib/sequel/extensions/batches.rb
@@ -6,12 +6,18 @@ module Sequel
     module Batches
       MissingPKError = Class.new(StandardError)
       NullPKError = Class.new(StandardError)
+      InvalidPKError = Class.new(StandardError)
 
       def in_batches(pk: nil, of: 1000, start: nil, finish: nil)
         pk ||= db.schema(first_source).select { |x| x[1][:primary_key] }.map(&:first)
         raise MissingPKError if pk.empty?
 
         qualified_pk = pk.map { |x| Sequel[first_source][x] }
+
+        check_pk = lambda do |input_pk|
+          raise InvalidPKError if input_pk.keys != pk
+          input_pk
+        end
 
         conditions = lambda do |pk, sign:|
           raise NullPKError if pk.values.any?(&:nil?)
@@ -20,8 +26,8 @@ module Sequel
         end
 
         base_ds = order(*qualified_pk)
-        base_ds = base_ds.where(conditions.call(start, sign: :>=)) if start
-        base_ds = base_ds.where(conditions.call(finish, sign: :<=)) if finish
+        base_ds = base_ds.where(conditions.call(check_pk.call(start), sign: :>=)) if start
+        base_ds = base_ds.where(conditions.call(check_pk.call(finish), sign: :<=)) if finish
 
         pk_ds = db.from(base_ds).select(*pk).order(*pk)
         actual_start = pk_ds.first

--- a/spec/sequel/extensions/batches_spec.rb
+++ b/spec/sequel/extensions/batches_spec.rb
@@ -82,6 +82,11 @@ RSpec.describe Sequel::Extensions::Batches do
     expect(chunks).to eq([[[15, 15, 15]], [[15, 20, 20]]])
   end
 
+  it "raises InvalidPKError in case of incorrect key ordering in start" do
+    expect { DB[:points].in_batches(pk: %i[x y z], start: {y: 16, z: 100, x: 15}) {} }
+      .to raise_error(Sequel::Extensions::Batches::InvalidPKError)
+  end
+
   it "raises MissingPKError in case of missing pk" do
     expect { DB[:points].in_batches {} }.to raise_error(Sequel::Extensions::Batches::MissingPKError)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,7 +49,6 @@ RSpec.configure do |config|
       column :x, "int"
       column :y, "int"
       column :z, "int"
-      primary_key %i[x y z]
     end
 
     DB[:points].multi_insert(YAML.load(IO.read("spec/fixtures/points.yml")))


### PR DESCRIPTION
Current version generates conditions like this:
```
(x > ?) OR (x = ? AND y > ?) OR (x = ? AND y = ? AND z > ?) OR (x = ? AND y = ? AND z = ?)
```

Now it generates smth like this:
```
row(x, y, z) >= row(?, ?, ?)
```

It doesn't work with NULLs, but I found out that current version skips rows with NULLs in some cases so it's unreliable. Also NULLs are normally not allowed in PK anyway. So now it throws NullPKError in case it founds a NULL in an actual row.

Also fixed MissingPKError being actually never thrown 👍  (added spec for that).