### PR TITLE
Fix dataset ordering for complex PK

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sequel-batches (2.0.0)
+    sequel-batches (2.0.1)
       sequel
 
 GEM
@@ -25,7 +25,7 @@ GEM
     method_source (1.0.0)
     minitest (5.16.2)
     parallel (1.22.1)
-    parser (3.1.2.0)
+    parser (3.1.2.1)
       ast (~> 2.4.1)
     pg (1.4.2)
     pry (0.14.1)
@@ -58,7 +58,7 @@ GEM
       rubocop-ast (>= 1.18.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.19.1)
+    rubocop-ast (1.21.0)
       parser (>= 3.1.1.0)
     rubocop-config-umbrellio (1.30.0.65)
       rubocop (~> 1.30.0)

--- a/lib/sequel/extensions/batches/yielder.rb
+++ b/lib/sequel/extensions/batches/yielder.rb
@@ -31,7 +31,7 @@ module Sequel::Extensions::Batches
             base_ds
           end
 
-        working_ds_pk = working_ds.select(*qualified_pk).order(order_by).limit(of)
+        working_ds_pk = working_ds.select(*qualified_pk).order(order_by(qualified: true)).limit(of)
         current_instance = db.from(working_ds_pk).select(*pk).order(order_by).last or break
         working_ds = working_ds.where(generate_conditions(current_instance.to_h, sign: sign_to_inclusive))
 

--- a/sequel-batches.gemspec
+++ b/sequel-batches.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name = "sequel-batches"
-  spec.version = "2.0.0"
+  spec.version = "2.0.1"
   spec.authors = %w[fiscal-cliff umbrellio]
   spec.email = ["oss@umbrellio.biz"]
   spec.required_ruby_version = ">= 2.7"


### PR DESCRIPTION
Without a patch it fails with the following error:

```
     Sequel::DatabaseError:
       PG::AmbiguousColumn: ERROR:  column reference "id" is ambiguous
       LINE 1: ..."created_at") <= row(6, '2017-05-01'))) ORDER BY ("id", "cre...
```