### PR TITLE
Optimize ordering

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sequel-batches (2.0.1)
+    sequel-batches (2.0.2)
       sequel
 
 GEM

--- a/lib/sequel/extensions/batches/yielder.rb
+++ b/lib/sequel/extensions/batches/yielder.rb
@@ -70,8 +70,8 @@ module Sequel::Extensions::Batches
     end
 
     def order_by(qualified: false)
-      columns = qualified ? qualified_pk : pk
-      asc_order? ? Sequel.asc(columns) : Sequel.desc(columns)
+      columns = qualified ? qualified_pk : pk.map { |x| x.is_a?(Symbol) ? Sequel[x] : x }
+      asc_order? ? columns.map(&:asc) : columns.map(&:desc)
     end
 
     def qualified_pk

--- a/lib/sequel/extensions/batches/yielder.rb
+++ b/lib/sequel/extensions/batches/yielder.rb
@@ -6,7 +6,7 @@ module Sequel::Extensions::Batches
     attr_writer :pk
 
     def initialize(ds:, **options)
-      self.ds = ds
+      self.ds = ds.unordered
       self.pk = options.delete(:pk)
       self.of = options.delete(:of) || 1000
       self.start = options.delete(:start)
@@ -31,8 +31,8 @@ module Sequel::Extensions::Batches
             base_ds
           end
 
-        working_ds_pk = working_ds.select(*qualified_pk).order(order_by(qualified: true)).limit(of)
-        current_instance = db.from(working_ds_pk).select(*pk).order(order_by).last or break
+        working_ds_pk = working_ds.select(*qualified_pk).order(*order_by(qualified: true)).limit(of)
+        current_instance = db.from(working_ds_pk).select(*pk).order(*order_by).last or break
         working_ds = working_ds.where(generate_conditions(current_instance.to_h, sign: sign_to_inclusive))
 
         yield working_ds
@@ -90,11 +90,11 @@ module Sequel::Extensions::Batches
     end
 
     def setup_base_ds
-      base_ds = ds.order(order_by(qualified: true))
+      base_ds = ds.order(*order_by(qualified: true))
       base_ds = base_ds.where(generate_conditions(check_pk(start), sign: sign_from_inclusive)) if start
       base_ds = base_ds.where(generate_conditions(check_pk(finish), sign: sign_to_inclusive)) if finish
 
-      pk_ds = db.from(base_ds.select(*qualified_pk)).select(*pk).order(order_by)
+      pk_ds = db.from(base_ds.select(*qualified_pk)).select(*pk).order(*order_by)
       actual_start = pk_ds.first
       actual_finish = pk_ds.last
 

--- a/lib/sequel/extensions/batches/yielder.rb
+++ b/lib/sequel/extensions/batches/yielder.rb
@@ -70,12 +70,16 @@ module Sequel::Extensions::Batches
     end
 
     def order_by(qualified: false)
-      columns = qualified ? qualified_pk : pk.map { |x| x.is_a?(Symbol) ? Sequel[x] : x }
+      columns = qualified ? qualified_pk : unqualified_pk
       asc_order? ? columns.map(&:asc) : columns.map(&:desc)
     end
 
     def qualified_pk
       @qualified_pk ||= pk.map { |x| Sequel[ds.first_source][x] }
+    end
+
+    def unqualified_pk
+      @unqualified_pk ||= pk.map { |x| x.is_a?(Symbol) ? Sequel[x] : x }
     end
 
     def check_pk(input_pk)

--- a/sequel-batches.gemspec
+++ b/sequel-batches.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name = "sequel-batches"
-  spec.version = "2.0.1"
+  spec.version = "2.0.2"
   spec.authors = %w[fiscal-cliff umbrellio]
   spec.email = ["oss@umbrellio.biz"]
   spec.required_ruby_version = ">= 2.7"


### PR DESCRIPTION
`ORDER BY (x, y)` doesn't use index where `ORDER BY x, y` does.